### PR TITLE
Handle video tag errors

### DIFF
--- a/lib/vjs-hls.js
+++ b/lib/vjs-hls.js
@@ -8,6 +8,28 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         var _hls;
         var _errorCounts = {};
 
+        _video.addEventListener('error', function(evt) {
+            var errorTxt,mediaError=evt.currentTarget.error;
+
+            switch(mediaError.code) {
+                case mediaError.MEDIA_ERR_ABORTED:
+                    errorTxt = "You aborted the video playback";
+                    break;
+                case mediaError.MEDIA_ERR_DECODE:
+                    errorTxt = "The video playback was aborted due to a corruption problem or because the video used features your browser did not support";
+                    _handleMediaError();
+                    break;
+                case mediaError.MEDIA_ERR_NETWORK:
+                    errorTxt = "A network error caused the video download to fail part-way";
+                    break;
+                case mediaError.MEDIA_ERR_SRC_NOT_SUPPORTED:
+                    errorTxt = "The video could not be loaded, either because the server or network failed or because the format is not supported";
+                    break;
+            }
+
+            console.error("MEDIA_ERROR: ", errorTxt);
+        });
+
         function initialize() {
             var hlsjsConfig = tech.options_.hlsjsConfig || {};
 
@@ -30,15 +52,31 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
             _hls.nextLevel = qualityId;
         }
 
-        function _onError(event, data, tech, errorCounts) {
+        function _handleMediaError() {
+            if (_errorCounts[Hls.ErrorTypes.MEDIA_ERROR] === 1) {
+                console.info("trying to recover media error");
+                _hls.recoverMediaError();
+            } else if (_errorCounts[Hls.ErrorTypes.MEDIA_ERROR] === 2) {
+                console.info("2nd try to recover media error (by swapping audio codec");
+                _hls.swapAudioCodec();
+                _hls.recoverMediaError();
+            } else if (_errorCounts[Hls.ErrorTypes.MEDIA_ERROR] > 2) {
+                console.info("bubbling media error up to VIDEOJS");
+                error.code = 3;
+                tech.error = function() { return error; };
+                tech.trigger('error');
+            }
+        }
+
+        function _onError(event, data) {
             var error = {
               message: ('HLS.js error: ' + data.type + ' - fatal: ' + data.fatal + ' - ' + data.details),
             };
             console.error(error.message);
 
             // increment/set error count
-            errorCounts[data.type] ? errorCounts[data.type] += 1 : errorCounts[data.type] = 1;
-            
+            _errorCounts[data.type] ? _errorCounts[data.type] += 1 : _errorCounts[data.type] = 1;
+
             // implement simple error handling based on hls.js documentation (https://github.com/dailymotion/hls.js/blob/master/API.md#fifth-step-error-handling)
             if (data.fatal) {
                 switch (data.type) {
@@ -50,19 +88,7 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
                         break;
 
                     case Hls.ErrorTypes.MEDIA_ERROR:
-                        if (errorCounts[data.type] === 1) {
-                          console.info("trying to recover media error");
-                          _hls.recoverMediaError();
-                        } else if (errorCounts[data.type] === 2) {
-                          console.info("2nd try to recover media error (by swapping audio codec");
-                          _hls.swapAudioCodec();
-                          _hls.recoverMediaError();
-                        } else if (errorCounts[data.type] > 2) {
-                          console.info("bubbling media error up to VIDEOJS");
-                          error.code = 3;
-                          tech.error = function() { return error; };
-                          tech.trigger('error');
-                        }
+                        _handleMediaError();
                         break;
 
                     default:

--- a/lib/vjs-hls.js
+++ b/lib/vjs-hls.js
@@ -70,7 +70,7 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
 
         function _onError(event, data) {
             var error = {
-              message: ('HLS.js error: ' + data.type + ' - fatal: ' + data.fatal + ' - ' + data.details),
+                message: ('HLS.js error: ' + data.type + ' - fatal: ' + data.fatal + ' - ' + data.details),
             };
             console.error(error.message);
 


### PR DESCRIPTION
Some media errors need to be handled on the video tag itself, as per https://github.com/dailymotion/hls.js/blob/master/demo/index.html#L638

This PR should fix #11 on Firefox. Tested with https://tv5mondehlslive-i.akamaihd.net/hls/live/250600/4792245510001-5/tv5plusinfo/index.m3u8
@TV5Dev, can you confirm and also test on IE11 and Edge?