### PR TITLE
Live streams are not detected properly

### DIFF
--- a/lib/vjs-hls.js
+++ b/lib/vjs-hls.js
@@ -7,6 +7,7 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
         var _video = tech.el();
         var _hls;
         var _errorCounts = {};
+        var _duration = null;
 
         _video.addEventListener('error', function(evt) {
             var errorTxt,mediaError=evt.currentTarget.error;
@@ -36,9 +37,14 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
             _hls = new Hls(hlsjsConfig);
             _hls.on(Hls.Events.ERROR, function(event, data) { _onError(event, data, tech, _errorCounts) });
             _hls.on(Hls.Events.MANIFEST_PARSED, _onMetaData);
+            _hls.on(Hls.Events.LEVEL_LOADED, function(event, data) { _duration = data.details.live ? Infinity : data.details.totalduration; });
 
             _hls.attachMedia(_video);
         }
+
+        this.duration = function () {
+            return _duration || _video.duration || 0;
+        };
 
         this.dispose = function () {
             _hls.destroy();


### PR DESCRIPTION
This pull request is meant to fix live streams in hls.
Video.js handles live streams by returning Infinity as duration in the interface.
If the Duration is less than Infinity, Video.js will show the seek bar, and will allow seeking within the buffer.