### PR TITLE
Video.js 6.x compatibility

### DIFF
--- a/lib/videojs5-hlsjs-source-handler.js
+++ b/lib/videojs5-hlsjs-source-handler.js
@@ -155,7 +155,10 @@ var attachVideojsStreamrootProvider = function (window, videojs, Hls) {
     }
 
     if (Hls.isSupported()) {
-        videojs.getComponent('Html5').registerSourceHandler({
+        var html5 = Number(videojs.VERSION.split(".")[0]) < 6 ?
+            videojs.getComponent('Html5') : videojs.getTech('Html5');
+
+        html5.registerSourceHandler({
 
             canHandleSource: function (source) {
 


### PR DESCRIPTION
This PR adds compatibility with Video.js 6.x (and future versions) by using `getComponent('html5') ` for older versions and `videojs.getTech('html5')` for version 6.x and higher.

Thanks very much!